### PR TITLE
Add textures and scene management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ FetchContent_MakeAvailable(yaml-cpp)
 # oneTBB
 add_subdirectory(third_party/oneTBB)
 
-file(GLOB SRC_FILES "src/*.cpp")
+file(GLOB_RECURSE SRC_FILES "src/*.cpp")
 add_executable(ray_tracing main.cpp ${SRC_FILES})
 
 target_include_directories(ray_tracing PRIVATE 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,3 +11,5 @@ samples_per_pixel: 500
 max_depth: 50
 
 gamma: 0.5
+scene: 0
+

--- a/config/small.yaml
+++ b/config/small.yaml
@@ -13,3 +13,4 @@ max_depth: 50
 gamma: 0.5
 
 num_threads: 8
+scene: 0

--- a/include/common.h
+++ b/include/common.h
@@ -8,3 +8,4 @@ using FloatType = double;
 constexpr FloatType infinity_f = std::numeric_limits<FloatType>::infinity();
 constexpr FloatType zero_f = static_cast<FloatType>(0.0);
 constexpr FloatType one_f = static_cast<FloatType>(1.0);
+constexpr FloatType pi = static_cast<FloatType>(3.1415926535897932385);

--- a/include/hittable.h
+++ b/include/hittable.h
@@ -13,6 +13,8 @@ struct HitRecord
     Vec3 normal;     // normal at the intersection point
     FloatType t;     // ray parameter at the intersection
     bool front_face; // whether the intersection is on the front face
+    FloatType u;
+    FloatType v;
 
     const Material *material;
 

--- a/include/material.h
+++ b/include/material.h
@@ -4,6 +4,7 @@
 #include "ray.h"
 #include "color.h"
 #include "rand_utils.h"
+#include "texture.h"
 
 struct Material
 {
@@ -15,7 +16,7 @@ struct Material
 
 struct Lambertian : public Material
 {
-    Lambertian(const Color &albedo) : albedo(albedo) {}
+    Lambertian(const Texture *albedo) : albedo(albedo) {}
 
     bool scatter(const Ray &r_in, const HitRecord &rec, Color &attenuation, Ray &scattered) const override
     {
@@ -23,10 +24,10 @@ struct Lambertian : public Material
         if (scatter_direction.near_zero())
             scatter_direction = rec.normal;
         scattered = Ray(rec.point, scatter_direction, r_in.time);
-        attenuation = albedo;
+        attenuation = albedo->value(rec.u, rec.v, rec.point);
         return true;
     }
-    Color albedo;
+    const Texture *albedo;
 };
 
 struct Metal : public Material

--- a/include/scene/scene_factory.h
+++ b/include/scene/scene_factory.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include "hittable_list.h"
+#include "material.h"
+#include "texture.h"
+
+struct Scene {
+    HittableList world;
+    std::vector<std::unique_ptr<Texture>> textures;
+    std::vector<std::unique_ptr<Material>> materials;
+};
+
+enum class SceneType {
+    Random = 0,
+    TwoSpheres = 1,
+    Earth = 2
+};
+
+Scene create_scene(SceneType type, FloatType time0, FloatType time1);
+

--- a/include/sphere.h
+++ b/include/sphere.h
@@ -52,6 +52,7 @@ struct Sphere : public Hittable
         hit_record.point = r.at(hit_record.t);
         Vec3 outward_normal = (hit_record.point - center_now) / radius;
         hit_record.set_face_normal(r, outward_normal);
+        get_sphere_uv(outward_normal, hit_record.u, hit_record.v);
         hit_record.material = material;
 
         return true;
@@ -72,5 +73,13 @@ struct Sphere : public Hittable
         AABB box0(center0 - r_vec, center0 + r_vec);
         AABB box1(center1 - r_vec, center1 + r_vec);
         return AABB::surrounding_box(box0, box1);
+    }
+
+    static void get_sphere_uv(const Vec3 &p, FloatType &u, FloatType &v)
+    {
+        auto theta = std::acos(-p.y);
+        auto phi = std::atan2(-p.z, p.x) + pi;
+        u = phi / (2 * pi);
+        v = theta / pi;
     }
 };

--- a/include/texture.h
+++ b/include/texture.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+#include "color.h"
+#include "math/vec3.h"
+
+struct Texture {
+    virtual ~Texture() = default;
+    virtual Color value(FloatType u, FloatType v, const Point3 &p) const = 0;
+};
+
+struct SolidColorTexture : public Texture {
+    SolidColorTexture(const Color &c) : color_value(c) {}
+    Color value(FloatType u, FloatType v, const Point3 &p) const override {
+        return color_value;
+    }
+    Color color_value;
+};
+
+struct CheckerTexture : public Texture {
+    CheckerTexture(std::unique_ptr<Texture> even, std::unique_ptr<Texture> odd, FloatType scale = 10.0)
+        : even(std::move(even)), odd(std::move(odd)), scale(scale) {}
+    Color value(FloatType u, FloatType v, const Point3 &p) const override {
+        auto s = std::sin(scale * p.x) * std::sin(scale * p.y) * std::sin(scale * p.z);
+        return s < 0 ? odd->value(u, v, p) : even->value(u, v, p);
+    }
+    std::unique_ptr<Texture> even;
+    std::unique_ptr<Texture> odd;
+    FloatType scale;
+};
+
+struct ImageTexture : public Texture {
+    ImageTexture(const std::string &filename);
+    ~ImageTexture();
+    Color value(FloatType u, FloatType v, const Point3 &p) const override;
+
+    unsigned char *data = nullptr;
+    int width = 0;
+    int height = 0;
+    int bytes_per_scanline = 0;
+};
+

--- a/src/scene/scene_factory.cpp
+++ b/src/scene/scene_factory.cpp
@@ -1,0 +1,99 @@
+#include "scene/scene_factory.h"
+#include "sphere.h"
+#include "texture.h"
+#include "rand_utils.h"
+
+static Scene random_scene(FloatType time0, FloatType time1) {
+    Scene scene;
+    auto ground_tex = std::make_unique<SolidColorTexture>(Color(0.5, 0.5, 0.5));
+    const Texture *ground_ptr = ground_tex.get();
+    scene.textures.push_back(std::move(ground_tex));
+    auto ground = std::make_unique<Lambertian>(ground_ptr);
+    scene.world.add(std::make_shared<Sphere>(Point3(0, -1000, 0), 1000, ground.get(), Motion(), time0));
+    scene.materials.push_back(std::move(ground));
+
+    for (int a = -11; a < 11; a++) {
+        for (int b = -11; b < 11; b++) {
+            auto choose_mat = random_float();
+            Point3 center(a + 0.9 * random_float(), 0.2, b + 0.9 * random_float());
+            if ((center - Point3(4, 0.2, 0)).norm() > 0.9) {
+                if (choose_mat < 0.8) {
+                    auto albedo = Color::random() * Color::random();
+                    auto tex = std::make_unique<SolidColorTexture>(albedo);
+                    const Texture *tex_ptr = tex.get();
+                    scene.textures.push_back(std::move(tex));
+                    auto mat = std::make_unique<Lambertian>(tex_ptr);
+                    auto motion = Motion(Vec3(0, random_float(0, 0.5), 0));
+                    scene.world.add(std::make_shared<Sphere>(center, 0.2, mat.get(), motion, time0));
+                    scene.materials.push_back(std::move(mat));
+                } else if (choose_mat < 0.95) {
+                    auto albedo = Color::random(0.5, 1);
+                    auto fuzz = random_float(0, 0.5);
+                    auto mat = std::make_unique<Metal>(albedo, fuzz);
+                    scene.world.add(std::make_shared<Sphere>(center, 0.2, mat.get(), Motion(), time0));
+                    scene.materials.push_back(std::move(mat));
+                } else {
+                    auto mat = std::make_unique<Dielectric>(1.5);
+                    scene.world.add(std::make_shared<Sphere>(center, 0.2, mat.get(), Motion(), time0));
+                    scene.materials.push_back(std::move(mat));
+                }
+            }
+        }
+    }
+
+    auto mat1 = std::make_unique<Dielectric>(1.5);
+    scene.world.add(std::make_shared<Sphere>(Point3(0, 1, 0), 1.0, mat1.get(), Motion(), time0));
+    scene.materials.push_back(std::move(mat1));
+
+    auto tex2 = std::make_unique<SolidColorTexture>(Color(0.4, 0.2, 0.1));
+    const Texture *tex2_ptr = tex2.get();
+    scene.textures.push_back(std::move(tex2));
+    auto mat2 = std::make_unique<Lambertian>(tex2_ptr);
+    scene.world.add(std::make_shared<Sphere>(Point3(-4, 1, 0), 1.0, mat2.get(), Motion(), time0));
+    scene.materials.push_back(std::move(mat2));
+
+    auto mat3 = std::make_unique<Metal>(Color(0.7, 0.6, 0.5), 0.0);
+    scene.world.add(std::make_shared<Sphere>(Point3(4, 1, 0), 1.0, mat3.get(), Motion(), time0));
+    scene.materials.push_back(std::move(mat3));
+
+    return scene;
+}
+
+static Scene two_spheres_scene(FloatType time0, FloatType time1) {
+    Scene scene;
+    auto checker = std::make_unique<CheckerTexture>(
+        std::make_unique<SolidColorTexture>(Color(0.2, 0.3, 0.1)),
+        std::make_unique<SolidColorTexture>(Color(0.9, 0.9, 0.9)),
+        10.0);
+    const Texture *checker_ptr = checker.get();
+    scene.textures.push_back(std::move(checker));
+    auto mat = std::make_unique<Lambertian>(checker_ptr);
+    scene.world.add(std::make_shared<Sphere>(Point3(0, -10, 0), 10, mat.get(), Motion(), time0));
+    scene.world.add(std::make_shared<Sphere>(Point3(0, 10, 0), 10, mat.get(), Motion(), time0));
+    scene.materials.push_back(std::move(mat));
+    return scene;
+}
+
+static Scene earth_scene(FloatType time0, FloatType time1) {
+    Scene scene;
+    auto earth = std::make_unique<ImageTexture>("earthmap.jpg");
+    const Texture *earth_ptr = earth.get();
+    scene.textures.push_back(std::move(earth));
+    auto mat = std::make_unique<Lambertian>(earth_ptr);
+    scene.world.add(std::make_shared<Sphere>(Point3(0, 0, 0), 2, mat.get(), Motion(), time0));
+    scene.materials.push_back(std::move(mat));
+    return scene;
+}
+
+Scene create_scene(SceneType type, FloatType time0, FloatType time1) {
+    switch (type) {
+    case SceneType::Random:
+        return random_scene(time0, time1);
+    case SceneType::TwoSpheres:
+        return two_spheres_scene(time0, time1);
+    case SceneType::Earth:
+        return earth_scene(time0, time1);
+    }
+    return Scene{};
+}
+

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -1,0 +1,33 @@
+#include "texture.h"
+#include <algorithm>
+#include "stb_image.h"
+
+ImageTexture::ImageTexture(const std::string &filename) {
+    int n = 0;
+    data = stbi_load(filename.c_str(), &width, &height, &n, 3);
+    bytes_per_scanline = width * 3;
+}
+
+ImageTexture::~ImageTexture() {
+    if (data) {
+        stbi_image_free(data);
+    }
+}
+
+Color ImageTexture::value(FloatType u, FloatType v, const Point3 &p) const {
+    if (data == nullptr) {
+        return Color(0, 1, 1);
+    }
+
+    u = std::clamp(u, static_cast<FloatType>(0.0), static_cast<FloatType>(1.0));
+    v = 1.0 - std::clamp(v, static_cast<FloatType>(0.0), static_cast<FloatType>(1.0));
+
+    int i = static_cast<int>(u * width);
+    int j = static_cast<int>(v * height);
+    if (i >= width) i = width - 1;
+    if (j >= height) j = height - 1;
+
+    const unsigned char *pixel = data + j * bytes_per_scanline + i * 3;
+    FloatType scale = 1.0 / 255.0;
+    return Color(scale * pixel[0], scale * pixel[1], scale * pixel[2]);
+}


### PR DESCRIPTION
## Summary
- introduce a texture system with solid color, checker and image textures
- extend materials and hittables to support textured rendering
- add scene factory and config option for switching scenes
- refactor texture ownership and scene factory

## Testing
- `cmake -S . -B build`
- `cmake --build build --target ray_tracing -j4`


------
https://chatgpt.com/codex/tasks/task_e_68bf5f0dcae0832ba7d0c5ce349c8c2c