### PR TITLE
Add Perlin noise texture and scene

### DIFF
--- a/include/math/vec3.h
+++ b/include/math/vec3.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <array>
 #include <cmath>
 #include <string>
 #include "common.h"
 
+struct Perlin;
 struct Vec3;
 
 Vec3 operator+(const Vec3 &u, const Vec3 &v);
@@ -131,7 +133,10 @@ struct Vec3
     }
 
 private:
-    Vec3() {}
+    Vec3() = default;
+    friend struct Perlin;
+template <typename, std::size_t>
+    friend struct std::array;
 };
 
 using Point3 = Vec3; // 3D point

--- a/include/perlin.h
+++ b/include/perlin.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <array>
+
+#include "math/vec3.h"
+#include "rand_utils.h"
+
+struct Perlin {
+    static constexpr int point_count = 256;
+
+    Perlin();
+
+    FloatType noise(const Point3 &p) const;
+    FloatType turb(const Point3 &p, int depth = 7) const;
+
+    std::array<Vec3, point_count> ranvec;
+    std::array<int, point_count> perm_x;
+    std::array<int, point_count> perm_y;
+    std::array<int, point_count> perm_z;
+};
+

--- a/include/scene/scene_factory.h
+++ b/include/scene/scene_factory.h
@@ -16,7 +16,8 @@ struct Scene {
 enum class SceneType {
     Random = 0,
     TwoSpheres = 1,
-    Earth = 2
+    Earth = 2,
+    Perlin = 3
 };
 
 Scene create_scene(SceneType type, FloatType time0, FloatType time1);

--- a/include/texture.h
+++ b/include/texture.h
@@ -6,6 +6,7 @@
 
 #include "color.h"
 #include "math/vec3.h"
+#include "perlin.h"
 
 struct Texture {
     virtual ~Texture() = default;
@@ -41,5 +42,14 @@ struct ImageTexture : public Texture {
     int width = 0;
     int height = 0;
     int bytes_per_scanline = 0;
+};
+
+struct NoiseTexture : public Texture {
+    NoiseTexture(FloatType scale = 1.0) : scale(scale) {}
+    Color value(FloatType u, FloatType v, const Point3 &p) const override {
+        return Color(1, 1, 1) * 0.5 * (1 + std::sin(scale * p.z + 10 * noise.turb(p)));
+    }
+    Perlin noise;
+    FloatType scale;
 };
 

--- a/src/perlin.cpp
+++ b/src/perlin.cpp
@@ -1,0 +1,72 @@
+#include "perlin.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+static void permute(std::array<int, Perlin::point_count> &p) {
+    for (int i = Perlin::point_count - 1; i > 0; --i) {
+        int target = static_cast<int>(random_float(0, i + 1));
+        std::swap(p[i], p[target]);
+    }
+}
+
+static FloatType perlin_interp(Vec3 c[2][2][2], FloatType u, FloatType v, FloatType w) {
+    auto uu = u * u * (3 - 2 * u);
+    auto vv = v * v * (3 - 2 * v);
+    auto ww = w * w * (3 - 2 * w);
+    FloatType accum = 0;
+    for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 2; ++j)
+            for (int k = 0; k < 2; ++k) {
+                Vec3 weight(u - i, v - j, w - k);
+                accum += (i * uu + (1 - i) * (1 - uu)) *
+                         (j * vv + (1 - j) * (1 - vv)) *
+                         (k * ww + (1 - k) * (1 - ww)) *
+                         Vec3::dot(c[i][j][k], weight);
+            }
+    return accum;
+}
+
+Perlin::Perlin() {
+    for (int i = 0; i < point_count; ++i) {
+        ranvec[i] = random_unit_sphere();
+        perm_x[i] = perm_y[i] = perm_z[i] = i;
+    }
+    permute(perm_x);
+    permute(perm_y);
+    permute(perm_z);
+}
+
+FloatType Perlin::noise(const Point3 &p) const {
+    auto u = p.x - std::floor(p.x);
+    auto v = p.y - std::floor(p.y);
+    auto w = p.z - std::floor(p.z);
+    int i = static_cast<int>(std::floor(p.x));
+    int j = static_cast<int>(std::floor(p.y));
+    int k = static_cast<int>(std::floor(p.z));
+    Vec3 c[2][2][2] = {
+        Vec3::uninitialized(), Vec3::uninitialized(),
+        Vec3::uninitialized(), Vec3::uninitialized(),
+        Vec3::uninitialized(), Vec3::uninitialized(),
+        Vec3::uninitialized(), Vec3::uninitialized()};
+    for (int di = 0; di < 2; ++di)
+        for (int dj = 0; dj < 2; ++dj)
+            for (int dk = 0; dk < 2; ++dk) {
+                int idx = perm_x[(i + di) & 255] ^ perm_y[(j + dj) & 255] ^ perm_z[(k + dk) & 255];
+                c[di][dj][dk] = ranvec[idx];
+            }
+    return perlin_interp(c, u, v, w);
+}
+
+FloatType Perlin::turb(const Point3 &p, int depth) const {
+    FloatType accum = 0;
+    Point3 temp = p;
+    FloatType weight = 1;
+    for (int i = 0; i < depth; ++i) {
+        accum += weight * noise(temp);
+        weight *= 0.5;
+        temp = temp * 2;
+    }
+    return std::fabs(accum);
+}
+

--- a/src/scene/scene_factory.cpp
+++ b/src/scene/scene_factory.cpp
@@ -85,6 +85,18 @@ static Scene earth_scene(FloatType time0, FloatType time1) {
     return scene;
 }
 
+static Scene perlin_scene(FloatType time0, FloatType time1) {
+    Scene scene;
+    auto pertext = std::make_unique<NoiseTexture>(4.0);
+    const Texture *pertext_ptr = pertext.get();
+    scene.textures.push_back(std::move(pertext));
+    auto mat = std::make_unique<Lambertian>(pertext_ptr);
+    scene.world.add(std::make_shared<Sphere>(Point3(0, -1000, 0), 1000, mat.get(), Motion(), time0));
+    scene.world.add(std::make_shared<Sphere>(Point3(0, 2, 0), 2, mat.get(), Motion(), time0));
+    scene.materials.push_back(std::move(mat));
+    return scene;
+}
+
 Scene create_scene(SceneType type, FloatType time0, FloatType time1) {
     switch (type) {
     case SceneType::Random:
@@ -93,6 +105,8 @@ Scene create_scene(SceneType type, FloatType time0, FloatType time1) {
         return two_spheres_scene(time0, time1);
     case SceneType::Earth:
         return earth_scene(time0, time1);
+    case SceneType::Perlin:
+        return perlin_scene(time0, time1);
     }
     return Scene{};
 }


### PR DESCRIPTION
## Summary
- make Vec3's default constructor private and use explicit uninitialized factory
- allocate Perlin interpolation cube with explicit Vec3::uninitialized

## Testing
- `cmake .. && make` *(fails: oneTBB test_dynamic_link string truncation)*
- `make ray_tracing`


------
https://chatgpt.com/codex/tasks/task_e_68bf7944f268832ba7d6ebbe81184b4e