### PR TITLE
Add lighting and Cornell box scene

### DIFF
--- a/config/cornell_box.yaml
+++ b/config/cornell_box.yaml
@@ -1,0 +1,14 @@
+image_width: 600
+image_height: 600
+
+fov: 40
+camera_position: [278, 278, 800]
+camera_look_at: [278, 278, 0]
+focus_dist: 10.0
+defocus_angle: 0.0
+
+samples_per_pixel: 200
+max_depth: 50
+
+gamma: 0.5
+scene: cornell_box

--- a/include/material.h
+++ b/include/material.h
@@ -12,6 +12,11 @@ struct Material
 
     virtual bool scatter(
         const Ray &r_in, const HitRecord &rec, Color &attenuation, Ray &scattered) const = 0;
+
+    virtual Color emitted(FloatType u, FloatType v, const Point3 &p) const
+    {
+        return Color::black();
+    }
 };
 
 struct Lambertian : public Material
@@ -84,5 +89,22 @@ struct Dielectric : public Material
         r0 = r0 * r0;
         return r0 + (1 - r0) * std::pow((1 - cosine), 5);
     }
+};
+
+struct DiffuseLight : public Material
+{
+    DiffuseLight(const Texture *emit) : emit(emit) {}
+
+    bool scatter(const Ray &, const HitRecord &, Color &, Ray &) const override
+    {
+        return false;
+    }
+
+    Color emitted(FloatType u, FloatType v, const Point3 &p) const override
+    {
+        return emit->value(u, v, p);
+    }
+
+    const Texture *emit;
 };
 

--- a/include/my_renderer.h
+++ b/include/my_renderer.h
@@ -11,6 +11,7 @@ public:
     void render(
         const Camera &camera,
         const HittableList &world,
+        const Color &background,
         std::uint8_t *buffer) const override;
 private:
     int samples_per_pixel;

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -4,6 +4,7 @@
 
 #include "camera.h"
 #include "hittable_list.h"
+#include "color.h"
 
 class Renderer
 {
@@ -12,5 +13,6 @@ public:
     virtual void render(
         const Camera &camera,
         const HittableList &world,
+        const Color &background,
         std::uint8_t *buffer) const = 0;
 };

--- a/include/scene/scene_factory.h
+++ b/include/scene/scene_factory.h
@@ -7,11 +7,13 @@
 #include "hittable_list.h"
 #include "material.h"
 #include "texture.h"
+#include "color.h"
 
 struct Scene {
     HittableList world;
     std::vector<std::unique_ptr<Texture>> textures;
     std::vector<std::unique_ptr<Material>> materials;
+    Color background = Color::black();
 };
 
 std::unique_ptr<Scene> create_scene(const std::string &type, FloatType time0, FloatType time1);

--- a/main.cpp
+++ b/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
     renderer = std::make_unique<MyRenderer>(samples_per_pixel, max_depth, gamma);
 
     auto start_time = std::chrono::high_resolution_clock::now();
-    renderer->render(camera, scene->world, pixels.data());
+    renderer->render(camera, scene->world, scene->background, pixels.data());
     auto end_time = std::chrono::high_resolution_clock::now();
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);

--- a/src/my_renderer.cpp
+++ b/src/my_renderer.cpp
@@ -16,31 +16,30 @@
 #include <tbb/blocked_range.h>
 #include <tbb/partitioner.h>
 
-Color ray_color(const Ray &r, int depth, const Hittable &world)
+Color ray_color(const Ray &r, int depth, const Hittable &world, const Color &background)
 {
     if (depth <= 0)
         return Color::black();
     HitRecord hit_record = HitRecord::uninitialized();
-    if (world.hit(r, Interval(static_cast<FloatType>(0.001), infinity_f), hit_record))
+    if (!world.hit(r, Interval(static_cast<FloatType>(0.001), infinity_f), hit_record))
     {
-        Ray scattered = Ray::uninitialized();
-        Color attenuation = Color::uninitialized();
-        if (hit_record.material && hit_record.material->scatter(r, hit_record, attenuation, scattered))
-        {
-            return attenuation * ray_color(scattered, depth - 1, world);
-        }
-        // No scattering, return black
-        return Color::black();
+        return background;
     }
 
-    Vec3 unit_direction = Vec3::normalize(r.direction);
-    auto a = static_cast<FloatType>(0.5) * (unit_direction.y + one_f);
-    return (one_f - a) * Color::white() + a * Color(static_cast<FloatType>(0.5), static_cast<FloatType>(0.7), static_cast<FloatType>(1.0));
+    Ray scattered = Ray::uninitialized();
+    Color attenuation = Color::uninitialized();
+    Color emitted = hit_record.material ? hit_record.material->emitted(hit_record.u, hit_record.v, hit_record.point) : Color::black();
+    if (!hit_record.material || !hit_record.material->scatter(r, hit_record, attenuation, scattered))
+    {
+        return emitted;
+    }
+    return emitted + attenuation * ray_color(scattered, depth - 1, world, background);
 }
 
 void MyRenderer::render(
     const Camera &camera,
     const HittableList &world,
+    const Color &background,
     std::uint8_t *buffer) const
 {
     auto objects = world.objects;
@@ -62,7 +61,7 @@ void MyRenderer::render(
                         FloatType v = static_cast<FloatType>(1.0) - (static_cast<FloatType>(j) + static_cast<FloatType>(0.5) + random_v) / camera.image_height; // flip v for image coordinates
 
                         Ray r = camera.get_ray(u, v);
-                        pixel_color_sum += ray_color(r, max_depth, bvh);
+                        pixel_color_sum += ray_color(r, max_depth, bvh, background);
                     }
 
                     pixel_color_sum = pixel_color_sum / static_cast<FloatType>(samples_per_pixel);

--- a/src/scene/scene_factory.cpp
+++ b/src/scene/scene_factory.cpp
@@ -10,6 +10,7 @@
 static std::unique_ptr<Scene> random_scene(FloatType time0, FloatType time1)
 {
     auto scene = std::make_unique<Scene>();
+    scene->background = Color(0.7, 0.8, 1.0);
     auto ground_tex = std::make_unique<SolidColorTexture>(Color(0.5, 0.5, 0.5));
     const Texture *ground_ptr = ground_tex.get();
     scene->textures.push_back(std::move(ground_tex));
@@ -75,6 +76,7 @@ static std::unique_ptr<Scene> random_scene(FloatType time0, FloatType time1)
 static std::unique_ptr<Scene> two_spheres_scene(FloatType time0, FloatType time1)
 {
     auto scene = std::make_unique<Scene>();
+    scene->background = Color(0.7, 0.8, 1.0);
     auto checker = std::make_unique<CheckerTexture>(
         std::make_unique<SolidColorTexture>(Color(0.2, 0.3, 0.1)),
         std::make_unique<SolidColorTexture>(Color(0.9, 0.9, 0.9)),
@@ -91,6 +93,7 @@ static std::unique_ptr<Scene> two_spheres_scene(FloatType time0, FloatType time1
 static std::unique_ptr<Scene> earth_scene(FloatType time0, FloatType time1)
 {
     auto scene = std::make_unique<Scene>();
+    scene->background = Color(0.7, 0.8, 1.0);
     auto earth = std::make_unique<ImageTexture>("assets/textures/earthmap.jpg");
     const Texture *earth_ptr = earth.get();
     scene->textures.push_back(std::move(earth));
@@ -103,6 +106,7 @@ static std::unique_ptr<Scene> earth_scene(FloatType time0, FloatType time1)
 static std::unique_ptr<Scene> perlin_scene(FloatType time0, FloatType time1)
 {
     auto scene = std::make_unique<Scene>();
+    scene->background = Color(0.7, 0.8, 1.0);
     auto pertext = std::make_unique<NoiseTexture>(4.0);
     const Texture *pertext_ptr = pertext.get();
     scene->textures.push_back(std::move(pertext));
@@ -116,6 +120,7 @@ static std::unique_ptr<Scene> perlin_scene(FloatType time0, FloatType time1)
 static std::unique_ptr<Scene> quads_scene(FloatType time0, FloatType time1)
 {
     auto scene = std::make_unique<Scene>();
+    scene->background = Color(0.7, 0.8, 1.0);
 
     {
         auto tex = std::make_unique<SolidColorTexture>(Color(1.0, 0.2, 0.2));
@@ -168,6 +173,7 @@ static std::unique_ptr<Scene> quads_scene(FloatType time0, FloatType time1)
 static std::unique_ptr<Scene> triangles_scene(FloatType time0, FloatType time1)
 {
     auto scene = std::make_unique<Scene>();
+    scene->background = Color(0.7, 0.8, 1.0);
 
     {
         auto ground_tex = std::make_unique<SolidColorTexture>(Color(0.8, 0.8, 0.8));
@@ -208,6 +214,46 @@ static std::unique_ptr<Scene> triangles_scene(FloatType time0, FloatType time1)
     return scene;
 }
 
+static std::unique_ptr<Scene> cornell_box_scene(FloatType time0, FloatType time1)
+{
+    auto scene = std::make_unique<Scene>();
+    scene->background = Color::black();
+
+    auto red_tex = std::make_unique<SolidColorTexture>(Color(0.65, 0.05, 0.05));
+    auto white_tex = std::make_unique<SolidColorTexture>(Color(0.73, 0.73, 0.73));
+    auto green_tex = std::make_unique<SolidColorTexture>(Color(0.12, 0.45, 0.15));
+    auto light_tex = std::make_unique<SolidColorTexture>(Color(15, 15, 15));
+
+    const Texture *red_ptr = red_tex.get();
+    const Texture *white_ptr = white_tex.get();
+    const Texture *green_ptr = green_tex.get();
+    const Texture *light_ptr = light_tex.get();
+
+    scene->textures.push_back(std::move(red_tex));
+    scene->textures.push_back(std::move(white_tex));
+    scene->textures.push_back(std::move(green_tex));
+    scene->textures.push_back(std::move(light_tex));
+
+    auto red = std::make_unique<Lambertian>(red_ptr);
+    auto white = std::make_unique<Lambertian>(white_ptr);
+    auto green = std::make_unique<Lambertian>(green_ptr);
+    auto light = std::make_unique<DiffuseLight>(light_ptr);
+
+    scene->world.add(std::make_shared<Quad>(Point3(555, 0, 0), Vec3(0, 555, 0), Vec3(0, 0, -555), green.get()));
+    scene->world.add(std::make_shared<Quad>(Point3(0, 0, -555), Vec3(0, 555, 0), Vec3(0, 0, 555), red.get()));
+    scene->world.add(std::make_shared<Quad>(Point3(0, 0, -555), Vec3(555, 0, 0), Vec3(0, 0, 555), white.get()));
+    scene->world.add(std::make_shared<Quad>(Point3(555, 555, -555), Vec3(-555, 0, 0), Vec3(0, 0, 555), white.get()));
+    scene->world.add(std::make_shared<Quad>(Point3(0, 555, -555), Vec3(555, 0, 0), Vec3(0, 0, 555), white.get()));
+    scene->world.add(std::make_shared<Quad>(Point3(213, 554, -332), Vec3(130, 0, 0), Vec3(0, 0, 105), light.get()));
+
+    scene->materials.push_back(std::move(red));
+    scene->materials.push_back(std::move(white));
+    scene->materials.push_back(std::move(green));
+    scene->materials.push_back(std::move(light));
+
+    return scene;
+}
+
 std::unique_ptr<Scene> create_scene(const std::string &type, FloatType time0, FloatType time1)
 {
     if (type == "random")
@@ -222,6 +268,8 @@ std::unique_ptr<Scene> create_scene(const std::string &type, FloatType time0, Fl
         return quads_scene(time0, time1);
     if (type == "triangles")
         return triangles_scene(time0, time1);
+    if (type == "cornell_box")
+        return cornell_box_scene(time0, time1);
     
     spdlog::warn("Unknown scene type '{}'. Returning empty scene.", type);
     return std::make_unique<Scene>();


### PR DESCRIPTION
## Summary
- add emissive `DiffuseLight` material and background-aware path tracing
- allow scenes to specify background color and render using it
- introduce Cornell box scene and config, featuring an area light

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68bfcd343fe0832b8926ef65f8a477f7