### PR TITLE
Add transform instances and Cornell box

### DIFF
--- a/include/instance.h
+++ b/include/instance.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <memory>
+#include <cmath>
+
+#include "hittable.h"
+#include "math/mat4.h"
+#include "motion.h"
+#include "aabb.h"
+
+struct Transform
+{
+    Mat4 matrix;
+    Mat4 inverse;
+    Mat4 inverse_transpose;
+    Motion motion;
+    FloatType time0;
+
+    Transform(const Mat4 &m = Mat4::identity(), const Motion &motion = Motion(), FloatType time0 = zero_f)
+        : matrix(m), inverse(m.inverse()), inverse_transpose(inverse.transpose()), motion(motion), time0(time0) {}
+};
+
+inline AABB transform_aabb(const AABB &box, const Mat4 &m)
+{
+    Point3 p[8] = {
+        {box.x.min, box.y.min, box.z.min},
+        {box.x.min, box.y.min, box.z.max},
+        {box.x.min, box.y.max, box.z.min},
+        {box.x.min, box.y.max, box.z.max},
+        {box.x.max, box.y.min, box.z.min},
+        {box.x.max, box.y.min, box.z.max},
+        {box.x.max, box.y.max, box.z.min},
+        {box.x.max, box.y.max, box.z.max}
+    };
+    Point3 q = m.transform_point(p[0]);
+    Point3 min = q;
+    Point3 max = q;
+    for (int i = 1; i < 8; ++i)
+    {
+        q = m.transform_point(p[i]);
+        min.x = std::fmin(min.x, q.x); min.y = std::fmin(min.y, q.y); min.z = std::fmin(min.z, q.z);
+        max.x = std::fmax(max.x, q.x); max.y = std::fmax(max.y, q.y); max.z = std::fmax(max.z, q.z);
+    }
+    return AABB(min, max);
+}
+
+struct Instance : public Hittable
+{
+    std::shared_ptr<Hittable> object;
+    std::shared_ptr<Transform> transform;
+
+    Instance(const std::shared_ptr<Hittable> &object, const std::shared_ptr<Transform> &transform)
+        : object(object), transform(transform) {}
+
+    bool hit(const Ray &r, Interval t_range, HitRecord &rec) const override
+    {
+        Vec3 offset = (r.time - transform->time0) * transform->motion.linear;
+        Point3 origin = transform->inverse.transform_point(r.origin - offset);
+        Vec3 direction = transform->inverse.transform_vector(r.direction);
+        Ray local_ray(origin, direction, r.time);
+        if (!object->hit(local_ray, t_range, rec))
+            return false;
+        rec.point = transform->matrix.transform_point(rec.point) + offset;
+        Vec3 n = transform->inverse_transpose.transform_vector(rec.normal);
+        rec.set_face_normal(r, Vec3::normalize(n));
+        return true;
+    }
+
+    AABB bounding_box() const override
+    {
+        return transform_aabb(object->bounding_box(), transform->matrix);
+    }
+
+    AABB bounding_box(FloatType t1) const override
+    {
+        // NOTE: Only linear translation is accounted for here; any rotational
+        // motion is ignored and may lead to an underestimated bounding box.
+        AABB box0 = transform_aabb(object->bounding_box(), transform->matrix);
+        Mat4 m1 = transform->matrix;
+        Vec3 trans = (t1 - transform->time0) * transform->motion.linear;
+        m1.set_translation(m1.get_translation() + trans);
+        AABB box1 = transform_aabb(object->bounding_box(), m1);
+        return AABB::surrounding_box(box0, box1);
+    }
+};
+

--- a/include/math/mat4.h
+++ b/include/math/mat4.h
@@ -66,6 +66,7 @@ struct Mat4
         return r;
     }
 
+    // Apply the full affine transform to a point (translation included).
     Vec3 transform_point(const Vec3 &v) const
     {
         FloatType x = m[0][0]*v.x + m[0][1]*v.y + m[0][2]*v.z + m[0][3];
@@ -77,6 +78,57 @@ struct Mat4
             x /= w; y /= w; z /= w;
         }
         return Vec3(x, y, z);
+    }
+
+    // Transform a direction vector (translation ignored).
+    Vec3 transform_vector(const Vec3 &v) const
+    {
+        return Vec3(
+            m[0][0]*v.x + m[0][1]*v.y + m[0][2]*v.z,
+            m[1][0]*v.x + m[1][1]*v.y + m[1][2]*v.z,
+            m[2][0]*v.x + m[2][1]*v.y + m[2][2]*v.z);
+    }
+
+    Mat4 transpose() const
+    {
+        Mat4 r = *this;
+        std::swap(r.m[0][1], r.m[1][0]);
+        std::swap(r.m[0][2], r.m[2][0]);
+        std::swap(r.m[0][3], r.m[3][0]);
+        std::swap(r.m[1][2], r.m[2][1]);
+        std::swap(r.m[1][3], r.m[3][1]);
+        std::swap(r.m[2][3], r.m[3][2]);
+        return r;
+    }
+
+    Mat4 inverse() const
+    {
+        Mat4 inv{};
+        const FloatType *a = &m[0][0];
+        FloatType invm[16];
+
+        invm[0] = a[5] * a[10] * a[15] - a[5] * a[11] * a[14] - a[9] * a[6] * a[15] + a[9] * a[7] * a[14] + a[13] * a[6] * a[11] - a[13] * a[7] * a[10];
+        invm[4] = -a[4] * a[10] * a[15] + a[4] * a[11] * a[14] + a[8] * a[6] * a[15] - a[8] * a[7] * a[14] - a[12] * a[6] * a[11] + a[12] * a[7] * a[10];
+        invm[8] = a[4] * a[9] * a[15] - a[4] * a[11] * a[13] - a[8] * a[5] * a[15] + a[8] * a[7] * a[13] + a[12] * a[5] * a[11] - a[12] * a[7] * a[9];
+        invm[12] = -a[4] * a[9] * a[14] + a[4] * a[10] * a[13] + a[8] * a[5] * a[14] - a[8] * a[6] * a[13] - a[12] * a[5] * a[10] + a[12] * a[6] * a[9];
+        invm[1] = -a[1] * a[10] * a[15] + a[1] * a[11] * a[14] + a[9] * a[2] * a[15] - a[9] * a[3] * a[14] - a[13] * a[2] * a[11] + a[13] * a[3] * a[10];
+        invm[5] = a[0] * a[10] * a[15] - a[0] * a[11] * a[14] - a[8] * a[2] * a[15] + a[8] * a[3] * a[14] + a[12] * a[2] * a[11] - a[12] * a[3] * a[10];
+        invm[9] = -a[0] * a[9] * a[15] + a[0] * a[11] * a[13] + a[8] * a[1] * a[15] - a[8] * a[3] * a[13] - a[12] * a[1] * a[11] + a[12] * a[3] * a[9];
+        invm[13] = a[0] * a[9] * a[14] - a[0] * a[10] * a[13] - a[8] * a[1] * a[14] + a[8] * a[2] * a[13] + a[12] * a[1] * a[10] - a[12] * a[2] * a[9];
+        invm[2] = a[1] * a[6] * a[15] - a[1] * a[7] * a[14] - a[5] * a[2] * a[15] + a[5] * a[3] * a[14] + a[13] * a[2] * a[7] - a[13] * a[3] * a[6];
+        invm[6] = -a[0] * a[6] * a[15] + a[0] * a[7] * a[14] + a[4] * a[2] * a[15] - a[4] * a[3] * a[14] - a[12] * a[2] * a[7] + a[12] * a[3] * a[6];
+        invm[10] = a[0] * a[5] * a[15] - a[0] * a[7] * a[13] - a[4] * a[1] * a[15] + a[4] * a[3] * a[13] + a[12] * a[1] * a[7] - a[12] * a[3] * a[5];
+        invm[14] = -a[0] * a[5] * a[14] + a[0] * a[6] * a[13] + a[4] * a[1] * a[14] - a[4] * a[2] * a[13] - a[12] * a[1] * a[6] + a[12] * a[2] * a[5];
+        invm[3] = -a[1] * a[6] * a[11] + a[1] * a[7] * a[10] + a[5] * a[2] * a[11] - a[5] * a[3] * a[10] - a[9] * a[2] * a[7] + a[9] * a[3] * a[6];
+        invm[7] = a[0] * a[6] * a[11] - a[0] * a[7] * a[10] - a[4] * a[2] * a[11] + a[4] * a[3] * a[10] + a[8] * a[2] * a[7] - a[8] * a[3] * a[6];
+        invm[11] = -a[0] * a[5] * a[11] + a[0] * a[7] * a[9] + a[4] * a[1] * a[11] - a[4] * a[3] * a[9] - a[8] * a[1] * a[7] + a[8] * a[3] * a[5];
+        invm[15] = a[0] * a[5] * a[10] - a[0] * a[6] * a[9] - a[4] * a[1] * a[10] + a[4] * a[2] * a[9] + a[8] * a[1] * a[6] - a[8] * a[2] * a[5];
+
+        FloatType det = a[0] * invm[0] + a[1] * invm[4] + a[2] * invm[8] + a[3] * invm[12];
+        FloatType inv_det = one_f / det;
+        for (int i = 0; i < 16; ++i)
+            (&inv.m[0][0])[i] = invm[i] * inv_det;
+        return inv;
     }
 
     void set_translation(const Vec3 &t)

--- a/include/primitives/sphere.h
+++ b/include/primitives/sphere.h
@@ -3,76 +3,53 @@
 #include <cmath>
 
 #include "math/vec3.h"
-#include "math/mat4.h"
 #include "hittable.h"
 #include "common.h"
-#include "motion.h"
 
 struct Sphere : public Hittable
 {
-    Mat4 transform;
-    Motion motion;
-    FloatType time0;
+    Point3 center;
     FloatType radius;
     const Material *material;
 
-    Sphere(const Mat4 &transform, FloatType radius, const Material *material, const Motion &motion = Motion(), FloatType time0 = zero_f)
-        : transform(transform), motion(motion), time0(time0), radius(std::fmax(radius, FloatType(0))), material(material) {}
-
-    Sphere(const Point3 &center, FloatType radius, const Material *material, const Motion &motion = Motion(), FloatType time0 = zero_f)
-        : transform(Mat4::translation(center)), motion(motion), time0(time0), radius(std::fmax(radius, FloatType(0))), material(material) {}
+    Sphere(const Point3 &center, FloatType radius, const Material *material)
+        : center(center), radius(std::fmax(radius, FloatType(0))), material(material) {}
 
     bool hit(const Ray &r, Interval t_range, HitRecord &hit_record) const override
     {
-        Vec3 center_now = transform.get_translation() + (r.time - time0) * motion.linear;
-        Vec3 oc = r.origin - center_now;
+        Vec3 oc = r.origin - center;
         FloatType a = r.direction.squared_norm();
         FloatType half_b = Vec3::dot(r.direction, oc);
         FloatType c = oc.squared_norm() - radius * radius;
         FloatType discriminant = half_b * half_b - a * c;
-
         if (discriminant < 0)
-        {
             return false;
-        }
         FloatType sqrt_d = std::sqrt(discriminant);
-
-        // Find the nearest root that lies in the acceptable range.
         FloatType root = (-half_b - sqrt_d) / a;
         if (!t_range.surrounds(root))
         {
             root = (-half_b + sqrt_d) / a;
             if (!t_range.surrounds(root))
-            {
                 return false;
-            }
         }
-
         hit_record.t = root;
         hit_record.point = r.at(hit_record.t);
-        Vec3 outward_normal = (hit_record.point - center_now) / radius;
+        Vec3 outward_normal = (hit_record.point - center) / radius;
         hit_record.set_face_normal(r, outward_normal);
         get_sphere_uv(outward_normal, hit_record.u, hit_record.v);
         hit_record.material = material;
-
         return true;
     }
 
     AABB bounding_box() const override
     {
-        Vec3 center = transform.get_translation();
         Vec3 r_vec(radius, radius, radius);
         return AABB(center - r_vec, center + r_vec);
     }
 
-    AABB bounding_box(FloatType t1) const override
+    AABB bounding_box(FloatType) const override
     {
-        Vec3 center0 = transform.get_translation();
-        Vec3 center1 = transform.get_translation() + (t1 - time0) * motion.linear;
-        Vec3 r_vec(radius, radius, radius);
-        AABB box0(center0 - r_vec, center0 + r_vec);
-        AABB box1(center1 - r_vec, center1 + r_vec);
-        return AABB::surrounding_box(box0, box1);
+        return bounding_box();
     }
 
     static void get_sphere_uv(const Vec3 &p, FloatType &u, FloatType &v)


### PR DESCRIPTION
## Summary
- add Transform/Instance system that applies shared motion and matrices to any hittable
- simplify Sphere primitive and extend Mat4 with inverse and transpose helpers
- create Cornell box scene with interior boxes using the new instance transforms
- clarify transform helpers, document AABB rotation limits, and restore motion to random scene

## Testing
- `git submodule update --init --recursive`
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68bfe5b2b724832bb80847f5e2658779