### PR TITLE
Add volumetric rendering and Cornell Box with fog

### DIFF
--- a/config/cornell_smoke.yaml
+++ b/config/cornell_smoke.yaml
@@ -1,0 +1,14 @@
+image_width: 600
+image_height: 600
+
+fov: 40
+camera_position: [278, 278, -800]
+camera_look_at: [278, 278, 0]
+focus_dist: 10.0
+defocus_angle: 0.0
+
+samples_per_pixel: 200
+max_depth: 50
+
+gamma: 0.5
+scene: cornell_smoke

--- a/include/material.h
+++ b/include/material.h
@@ -108,3 +108,17 @@ struct DiffuseLight : public Material
     const Texture *emit;
 };
 
+struct Isotropic : public Material
+{
+    Isotropic(const Texture *albedo) : albedo(albedo) {}
+
+    bool scatter(const Ray &r_in, const HitRecord &rec, Color &attenuation, Ray &scattered) const override
+    {
+        scattered = Ray(rec.point, random_unit_sphere(), r_in.time);
+        attenuation = albedo->value(rec.u, rec.v, rec.point);
+        return true;
+    }
+
+    const Texture *albedo;
+};
+

--- a/include/primitives/constant_medium.h
+++ b/include/primitives/constant_medium.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <memory>
+#include <cmath>
+
+#include "hittable.h"
+#include "material.h"
+#include "rand_utils.h"
+
+struct ConstantMedium : public Hittable
+{
+    std::shared_ptr<Hittable> boundary;
+    const Material *phase_function;
+    FloatType neg_inv_density;
+
+    ConstantMedium(const std::shared_ptr<Hittable> &boundary, FloatType density, const Material *phase_function)
+        : boundary(boundary), phase_function(phase_function), neg_inv_density(-one_f / density) {}
+
+    bool hit(const Ray &r, Interval t_range, HitRecord &rec) const override
+    {
+        HitRecord rec1 = HitRecord::uninitialized();
+        HitRecord rec2 = HitRecord::uninitialized();
+
+        if (!boundary->hit(r, Interval(-infinity_f, infinity_f), rec1))
+            return false;
+        if (!boundary->hit(r, Interval(rec1.t + 0.0001, infinity_f), rec2))
+            return false;
+
+        if (rec1.t < t_range.min)
+            rec1.t = t_range.min;
+        if (rec2.t > t_range.max)
+            rec2.t = t_range.max;
+        if (rec1.t >= rec2.t)
+            return false;
+        if (rec1.t < 0)
+            rec1.t = 0;
+
+        FloatType ray_length = r.direction.norm();
+        FloatType distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
+        FloatType hit_distance = neg_inv_density * std::log(random_float());
+
+        if (hit_distance > distance_inside_boundary)
+            return false;
+
+        rec.t = rec1.t + hit_distance / ray_length;
+        rec.point = r.at(rec.t);
+        rec.normal = Vec3(1, 0, 0);
+        rec.front_face = true;
+        rec.material = phase_function;
+        rec.u = 0;
+        rec.v = 0;
+        return true;
+    }
+
+    AABB bounding_box() const override { return boundary->bounding_box(); }
+    AABB bounding_box(FloatType time1) const override { return boundary->bounding_box(time1); }
+};
+


### PR DESCRIPTION
## Summary
- implement isotropic material and constant medium volume
- add Cornell Smoke scene with volumetric fog and config
- move constant medium header into primitives directory for consistency

## Testing
- `git submodule update --init --recursive .`
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68bffa5780d0832b883b5189ca8cbebc